### PR TITLE
added default value as "" for watsapp variables

### DIFF
--- a/helm_charts/router/values.j2
+++ b/helm_charts/router/values.j2
@@ -27,6 +27,6 @@ routerenv:
   sunbird_api_auth_token: "{{ sunbird_api_auth_token_bot }}"
   telemetry_service_url: "https://{{ domain_name }}/api/data/"
   WHATSAPP_TELEMETRY_CHANNEL: '"{{sunbird_whatsapp_telemetry_channel | default("")}}"'
-  WHATSAPP_SECRET_KEY: "{{sunbird_whatsapp_secret_key | default("")}}"
-  WHATSAPP_AUTH_TOKEN: "{{sunbird_whatsapp_auth_token | default("")}}"
-  WHATSAPP_SOURCE: "{{sunbird_whatsapp_source | default("")}}"
+  WHATSAPP_SECRET_KEY: "{{sunbird_whatsapp_secret_key | default("''")}}"
+  WHATSAPP_AUTH_TOKEN: "{{sunbird_whatsapp_auth_token | default("''")}}"
+  WHATSAPP_SOURCE: "{{sunbird_whatsapp_source | default("''")}}"


### PR DESCRIPTION
we have not defined value for watsapp variables in dev and staging, so adding default value.
 helm chart will remove one quotes while templating, so adding 2 quotes